### PR TITLE
Prevent warning "undefined method `strip' for nil:NilClass"

### DIFF
--- a/lib/facter/ipa_version.rb
+++ b/lib/facter/ipa_version.rb
@@ -31,11 +31,11 @@ if ipa == ''
 	ipa = 'ipa-server'
 end
 
+#confine :operatingsystem => %w{CentOS, RedHat, Fedora}
+# TODO: add a long TTL to avoid repeated yum noise
 cmdout = Facter::Util::Resolution.exec(yum+" info "+ipa+" 2> /dev/null | /bin/grep '^Version' | /bin/awk -F ':' '{print $2}'")
 if cmdout != nil
 	Facter.add('ipa_version') do
-		#confine :operatingsystem => %w{CentOS, RedHat, Fedora}
-		# TODO: add a long TTL to avoid repeated yum noise
 		setcode {
 			cmdout.strip
 		}


### PR DESCRIPTION
After adding this module to our Puppet server, we started getting the following warning on our non-RH/CentOS/Fedora boxes:

Could not retrieve fact='ipa_version', resolution='<anonymous>': undefined method `strip' for nil:NilClass

I've rearranged the offending code such that it won't even try to set up a new ipa_version fact if the exec of yum outputs nothing.

Existing comments suggest only acting on RH/CentOS/Fedora, but I suspect the warning would still appear if IPA weren't installed on a particular system.  This will keep it quiet in that case as well.
