### PR TITLE
corrected syntax for multiple bind packages

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -197,7 +197,7 @@ class ipa::server(
 	$valid_fqdn = "${valid_hostname}.${valid_domain}"
 
 	if $dns {
-		package { "${::ipa::params::package_bind}":
+		package { $::ipa::params::package_bind:
 			ensure => present,
 			before => Package["${::ipa::params::package_ipa_server}"],
 		}


### PR DESCRIPTION
Currently the installation of bind packages fails because the packages are defined as a list but are turned into a string when defining the package.

Thanks for your time.
