### PR TITLE
Puppet 4x support

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -92,7 +92,7 @@ class ipa::client(
 		content => "${password}\n",		# temporarily secret...
 		owner => root,
 		group => nobody,
-		mode => 600,	# u=rw,go=
+		mode => '600',	# u=rw,go=
 		backup => false,
 		require => File["${vardir}/"],
 		ensure => present,
@@ -158,7 +158,7 @@ class ipa::client(
 		content => "true\n",
 		owner => root,
 		group => nobody,
-		mode => 600,	# u=rw,go=
+		mode => '600',	# u=rw,go=
 		backup => false,
 		require => [
 			File["${vardir}/"],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -63,7 +63,7 @@ class ipa::params(
 			content => inline_template('<%= @hash.to_yaml %>'),
 			owner => root,
 			group => root,
-			mode => 644,		# u=rw,go=r
+			mode => '644',		# u=rw,go=r
 			ensure => present,
 		}
 	}

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -71,7 +71,7 @@ class ipa::server(
 	$peer_excludes = [],		# never purge these peer excludes...
 	$ensure = present		# TODO: support uninstall with 'absent'
 ) {
-	$fw = '$FW'			# make using $fw in shorewall easier...
+	$fw = '$FW'			# make using $FW in shorewall easier...
 
 	# TODO: should we always include the replica peering or only when used?
 	include ipa::server::replica::peering
@@ -644,46 +644,46 @@ class ipa::server(
 		#ACTION      SOURCE DEST                PROTO DEST  SOURCE  ORIGINAL
 		#                                             PORT  PORT(S) DEST
 		shorewall::rule { 'http': rule => "
-		HTTP/ACCEPT  ${net}    $fw
+		HTTP/ACCEPT  ${net}    ${fw}
 		", comment => 'Allow HTTP for webui'}
 
 		shorewall::rule { 'https': rule => "
-		HTTPS/ACCEPT  ${net}    $fw
+		HTTPS/ACCEPT  ${net}    ${fw}
 		", comment => 'Allow HTTPS for webui'}
 
 		shorewall::rule { 'ldap': rule => "
-		LDAP/ACCEPT  ${net}    $fw
+		LDAP/ACCEPT  ${net}    ${fw}
 		", comment => 'Allow LDAP for 389 server on tcp port 389.'}
 
 		shorewall::rule { 'ldaps': rule => "
-		LDAPS/ACCEPT  ${net}    $fw
+		LDAPS/ACCEPT  ${net}    ${fw}
 		", comment => 'Allow LDAPS for 389 server on tcp port 636.'}
 
 		shorewall::rule { 'kerberos': rule => "
-		Kerberos/ACCEPT  ${net}    $fw
+		Kerberos/ACCEPT  ${net}    ${fw}
 		", comment => 'Allow Kerberos for krb5 server on tcp/udp port 88.'}
 
 		# TODO: should i propose this as a shorewall macro ?
 		shorewall::rule { 'kpasswd': rule => "
-		ACCEPT  ${net}    $fw    tcp  464
-		ACCEPT  ${net}    $fw    udp  464
+		ACCEPT  ${net}    ${fw}    tcp  464
+		ACCEPT  ${net}    ${fw}    udp  464
 		", comment => 'Allow Kerberos for kpasswd on tcp/udp port 464.'}
 
 		if $ntp {
 			shorewall::rule { 'ntp': rule => "
-			NTP/ACCEPT  ${net}    $fw
+			NTP/ACCEPT  ${net}    ${fw}
 			", comment => 'Allow NTP on udp port 123.'}
 		}
 
 		if $dns {
 			shorewall::rule { 'dns': rule => "
-			DNS/ACCEPT  ${net}    $fw
+			DNS/ACCEPT  ${net}    ${fw}
 			", comment => 'Allow DNS on tcp/udp port 53.'}
 		}
 
 		if $dogtag {
 			shorewall::rule { 'dogtag': rule => "
-			ACCEPT  ${net}    $fw    tcp  7389
+			ACCEPT  ${net}    ${fw}    tcp  7389
 			", comment => 'Allow dogtag certificate system on tcp port 7389.'}
 		}
 	}

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -71,7 +71,7 @@ class ipa::server(
 	$peer_excludes = [],		# never purge these peer excludes...
 	$ensure = present		# TODO: support uninstall with 'absent'
 ) {
-	$FW = '$FW'			# make using $FW in shorewall easier...
+	$fw = '$FW'			# make using $fw in shorewall easier...
 
 	# TODO: should we always include the replica peering or only when used?
 	include ipa::server::replica::peering
@@ -120,7 +120,7 @@ class ipa::server(
 		'flat' => ipa_topology_flat($replica_peers),
 		'ring' => ipa_topology_ring($replica_peers),
 		#'manual' => $peers,
-		default => type($peers) ? {	# 'manual' (default) peering...
+		default => type3x($peers) ? {	# 'manual' (default) peering...
 			'hash' => $peers,	# TODO: validate this data type
 			default => $empty_hash,	# invalid data...
 		},
@@ -153,7 +153,7 @@ class ipa::server(
 		value => "${default_email_domain}",
 	}
 
-	$default_shell = type($shell) ? {
+	$default_shell = type3x($shell) ? {
 		'boolean' => $shell ? {
 			false => false,		# unmanaged
 			default => '/bin/sh',	# the default
@@ -161,21 +161,21 @@ class ipa::server(
 		default => "${shell}",
 	}
 	# we don't manage if value is false, otherwise it's good to go!
-	if ! (type($shell) == 'boolean' and (! $shell)) {
+	if ! (type3x($shell) == 'boolean' and (! $shell)) {
 		ipa::server::config { 'shell':
 			value => "${default_shell}",
 		}
 	}
 
 	# TODO: the home stuff seems to not use trailing slashes. can i add it?
-	$default_homes = type($homes) ? {
+	$default_homes = type3x($homes) ? {
 		'boolean' => $homes ? {
 			false => false,		# unmanaged
 			default => '/home',	# the default
 		},
 		default => "${homes}",
 	}
-	if ! (type($homes) == 'boolean' and (! $homes)) {
+	if ! (type3x($homes) == 'boolean' and (! $homes)) {
 		ipa::server::config { 'homes':
 			value => "${default_homes}",	# XXX: remove trailing slash if present ?
 		}
@@ -227,7 +227,7 @@ class ipa::server(
 		source => 'puppet:///modules/ipa/diff.py',
 		owner => root,
 		group => nobody,
-		mode => 700,			# u=rwx
+		mode => '700',			# u=rwx
 		backup => false,		# don't backup to filebucket
 		ensure => present,
 		require => [
@@ -261,7 +261,7 @@ class ipa::server(
 			purge => true,		# don't purge unmanaged files
 			force => true,		# don't purge subdirs and links
 			# group and other must not have perms or gpg complains!
-			mode => 600,		# u=rw,go=
+			mode => '600',		# u=rw,go=
 			backup => false,
 			require => File["${vardir}/"],
 		}
@@ -271,7 +271,7 @@ class ipa::server(
 		file { "${dm_password_filename}":
 			owner => root,
 			group => nobody,
-			mode => 600,	# u=rw,go=
+			mode => '600',	# u=rw,go=
 			backup => false,
 			require => File["${vardir}/gpg/"],
 			ensure => present,
@@ -282,7 +282,7 @@ class ipa::server(
 		file { "${admin_password_filename}":
 			owner => root,
 			group => nobody,
-			mode => 600,	# u=rw,go=
+			mode => '600',	# u=rw,go=
 			backup => false,
 			require => File["${vardir}/gpg/"],
 			ensure => present,
@@ -292,7 +292,7 @@ class ipa::server(
 		file { "${vardir}/gpg/pubring.gpg":
 			owner => root,
 			group => nobody,
-			mode => 600,	# u=rw,go=
+			mode => '600',	# u=rw,go=
 			backup => false,
 			require => File["${vardir}/gpg/"],
 			ensure => present,
@@ -301,7 +301,7 @@ class ipa::server(
 		file { "${vardir}/gpg/secring.gpg":
 			owner => root,
 			group => nobody,
-			mode => 600,	# u=rw,go=
+			mode => '600',	# u=rw,go=
 			backup => false,
 			require => File["${vardir}/gpg/"],
 			ensure => present,
@@ -312,7 +312,7 @@ class ipa::server(
 		file { "${vardir}/gpg/trustdb.gpg":
 			owner => root,
 			group => nobody,
-			mode => 600,	# u=rw,go=
+			mode => '600',	# u=rw,go=
 			backup => false,
 			require => File["${vardir}/gpg/"],
 			ensure => present,
@@ -332,7 +332,7 @@ class ipa::server(
 			},
 			owner => root,
 			group => nobody,
-			mode => 600,	# u=rw,go=
+			mode => '600',	# u=rw,go=
 			backup => false,
 			before => Exec['ipa-gpg-import'],
 			require => File["${vardir}/gpg/"],
@@ -430,7 +430,7 @@ class ipa::server(
 			content => "${dm_password}\n",		# top top secret!
 			owner => root,
 			group => nobody,
-			mode => 600,	# u=rw,go=
+			mode => '600',	# u=rw,go=
 			backup => false,
 			before => Exec['ipa-install'],
 			require => File["${vardir}/"],
@@ -447,7 +447,7 @@ class ipa::server(
 			content => "${admin_password}\n",	# top secret!
 			owner => root,
 			group => nobody,
-			mode => 600,	# u=rw,go=
+			mode => '600',	# u=rw,go=
 			backup => false,
 			before => Exec['ipa-install'],
 			require => File["${vardir}/"],
@@ -533,7 +533,7 @@ class ipa::server(
 		content => inline_template("#!/bin/bash\n${::ipa::params::program_ipa_server_install} ${args} --unattended && /bin/echo '${::fqdn}' > ${vardir}/ipa_server_replica_master\n"),
 		owner => root,
 		group => root,
-		mode => 700,
+		mode => '700',
 		ensure => present,
 		require => File["${vardir}/"],
 	}
@@ -575,7 +575,7 @@ class ipa::server(
 	file { "${vardir}/ipa_server_replica_master":
 		owner => root,
 		group => nobody,
-		mode => 600,	# u=rw,go=
+		mode => '600',	# u=rw,go=
 		backup => false,
 		require => [
 			File["${vardir}/"],
@@ -590,7 +590,7 @@ class ipa::server(
 		#content => "true\n",
 		owner => root,
 		group => nobody,
-		mode => 600,	# u=rw,go=
+		mode => '600',	# u=rw,go=
 		backup => false,
 		require => [
 			File["${vardir}/"],
@@ -644,46 +644,46 @@ class ipa::server(
 		#ACTION      SOURCE DEST                PROTO DEST  SOURCE  ORIGINAL
 		#                                             PORT  PORT(S) DEST
 		shorewall::rule { 'http': rule => "
-		HTTP/ACCEPT  ${net}    $FW
+		HTTP/ACCEPT  ${net}    $fw
 		", comment => 'Allow HTTP for webui'}
 
 		shorewall::rule { 'https': rule => "
-		HTTPS/ACCEPT  ${net}    $FW
+		HTTPS/ACCEPT  ${net}    $fw
 		", comment => 'Allow HTTPS for webui'}
 
 		shorewall::rule { 'ldap': rule => "
-		LDAP/ACCEPT  ${net}    $FW
+		LDAP/ACCEPT  ${net}    $fw
 		", comment => 'Allow LDAP for 389 server on tcp port 389.'}
 
 		shorewall::rule { 'ldaps': rule => "
-		LDAPS/ACCEPT  ${net}    $FW
+		LDAPS/ACCEPT  ${net}    $fw
 		", comment => 'Allow LDAPS for 389 server on tcp port 636.'}
 
 		shorewall::rule { 'kerberos': rule => "
-		Kerberos/ACCEPT  ${net}    $FW
+		Kerberos/ACCEPT  ${net}    $fw
 		", comment => 'Allow Kerberos for krb5 server on tcp/udp port 88.'}
 
 		# TODO: should i propose this as a shorewall macro ?
 		shorewall::rule { 'kpasswd': rule => "
-		ACCEPT  ${net}    $FW    tcp  464
-		ACCEPT  ${net}    $FW    udp  464
+		ACCEPT  ${net}    $fw    tcp  464
+		ACCEPT  ${net}    $fw    udp  464
 		", comment => 'Allow Kerberos for kpasswd on tcp/udp port 464.'}
 
 		if $ntp {
 			shorewall::rule { 'ntp': rule => "
-			NTP/ACCEPT  ${net}    $FW
+			NTP/ACCEPT  ${net}    $fw
 			", comment => 'Allow NTP on udp port 123.'}
 		}
 
 		if $dns {
 			shorewall::rule { 'dns': rule => "
-			DNS/ACCEPT  ${net}    $FW
+			DNS/ACCEPT  ${net}    $fw
 			", comment => 'Allow DNS on tcp/udp port 53.'}
 		}
 
 		if $dogtag {
 			shorewall::rule { 'dogtag': rule => "
-			ACCEPT  ${net}    $FW    tcp  7389
+			ACCEPT  ${net}    $fw    tcp  7389
 			", comment => 'Allow dogtag certificate system on tcp port 7389.'}
 		}
 	}

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -102,7 +102,7 @@ define ipa::server::config(
 		fail("Key '${key}' is invalid.")
 	}
 
-	if type($value) != "${etype}" {
+	if type3x($value) != "${etype}" {
 		fail("Ipa::Server::Config[${key}] must be type: ${etype}.")
 	}
 
@@ -127,7 +127,7 @@ define ipa::server::config(
 		fail("Unknown type: ${etype}.")
 	}
 
-	$cutlength = inline_template('<%= (rawkey.length+2).to_s %>')
+        $cutlength = 2 + size($rawkey)
 	exec { "/usr/bin/ipa config-mod ${option}'${safe_value}'":
 		logoutput => on_failure,
 		onlyif => "${::ipa::common::ipa_installed}",

--- a/manifests/server/host.pp
+++ b/manifests/server/host.pp
@@ -64,7 +64,7 @@ define ipa::server::host(
 		default => "${name}",			# had dots present...
 	}
 
-	$valid_sshpubkeys = type($sshpubkeys) ? {
+	$valid_sshpubkeys = type3x($sshpubkeys) ? {
 		'string' => "${sshpubkeys}" ? {
 			# BUG: lol: https://projects.puppetlabs.com/issues/15813
 			'' => [],	# assume managed but empty (rm sshkeys)
@@ -103,7 +103,7 @@ define ipa::server::host(
 	# array means: managed, set these keys exactly, and remove when it's []
 	# boolean false means: unmanaged, don't set or get anything... empty ''
 	# boolean true means: managed, get the keys automatically (super magic)
-	$args02 = type($valid_sshpubkeys) ? {
+	$args02 = type3x($valid_sshpubkeys) ? {
 		# we always have to at least specify the '--sshpubkey=' if this
 		# is empty, because otherwise we have no way to remove old keys
 		'array' => inline_template('<% if valid_sshpubkeys == [] %>--sshpubkey=<% else %><%= valid_sshpubkeys.map {|x| "--sshpubkey=\'"+x+"\'" }.join(" ") %><% end %>'),
@@ -176,7 +176,7 @@ define ipa::server::host(
 		content => "${valid_fqdn}\n${args}\n",
 		owner => root,
 		group => nobody,
-		mode => 600,	# u=rw,go=
+		mode => '600',	# u=rw,go=
 		require => File["${vardir}/hosts/"],
 		ensure => present,
 	}
@@ -185,7 +185,7 @@ define ipa::server::host(
 		content => "${valid_fqdn}\n${qargs}\n",
 		owner => root,
 		group => nobody,
-		mode => 600,	# u=rw,go=
+		mode => '600',	# u=rw,go=
 		require => File["${vardir}/hosts/"],
 		ensure => present,
 	}
@@ -196,7 +196,7 @@ define ipa::server::host(
 			# no content! this is a tag, content comes in by echo !
 			owner => root,
 			group => nobody,
-			mode => 600,	# u=rw,go=
+			mode => '600',	# u=rw,go=
 			backup => false,
 			notify => $modify ? {
 				false => undef,	# can't notify if not modifying
@@ -210,7 +210,7 @@ define ipa::server::host(
 			content => "${password}\n",	# top secret (briefly!)
 			owner => root,
 			group => nobody,
-			mode => 600,	# u=rw,go=
+			mode => '600',	# u=rw,go=
 			backup => false,
 			notify => $modify ? {
 				false => undef,	# can't notify if not modifying
@@ -230,7 +230,7 @@ define ipa::server::host(
 		recurse => true,		# recursively manage directory
 		purge => true,			# purge all unmanaged files
 		force => true,			# also purge subdirs and links
-		owner => root, group => nobody, mode => 600, backup => false,
+		owner => root, group => nobody, mode => '600', backup => false,
 		require => File["${vardir}/hosts/sshpubkeys/"],
 	}
 

--- a/manifests/server/host/base.pp
+++ b/manifests/server/host/base.pp
@@ -26,7 +26,7 @@ class ipa::server::host::base {
 	$valid_domain = $ipa::server::valid_domain
 	$host_always_ignore = ["${valid_hostname}.${valid_domain}"]
 	$host_excludes = $ipa::server::host_excludes
-	$valid_host_excludes = type($host_excludes) ? {
+	$valid_host_excludes = type3x($host_excludes) ? {
 		'string' => [$host_excludes],
 		'array' => $host_excludes,
 		'boolean' => $host_excludes ? {
@@ -39,7 +39,7 @@ class ipa::server::host::base {
 		default => false,	# trigger error...
 	}
 
-	if type($valid_host_excludes) != 'array' {
+	if type3x($valid_host_excludes) != 'array' {
 		fail('The $host_excludes must be an array.')
 	}
 
@@ -49,7 +49,7 @@ class ipa::server::host::base {
 		recurse => true,		# recursively manage directory
 		purge => true,			# purge all unmanaged files
 		force => true,			# also purge subdirs and links
-		owner => root, group => nobody, mode => 600, backup => false,
+		owner => root, group => nobody, mode => '600', backup => false,
 		notify => Exec['ipa-clean-hosts'],
 		require => File["${vardir}/"],
 	}
@@ -73,7 +73,7 @@ class ipa::server::host::base {
 		content => template('ipa/clean.sh.erb'),
 		owner => root,
 		group => nobody,
-		mode => 700,			# u=rwx
+		mode => '700',			# u=rwx
 		backup => false,		# don't backup to filebucket
 		ensure => present,
 		require => File["${vardir}/"],
@@ -96,7 +96,7 @@ class ipa::server::host::base {
 		recurse => true,		# recursively manage directory
 		purge => true,			# purge all unmanaged files
 		force => true,			# also purge subdirs and links
-		owner => root, group => nobody, mode => 600, backup => false,
+		owner => root, group => nobody, mode => '600', backup => false,
 		require => File["${vardir}/hosts/"],
 	}
 
@@ -105,7 +105,7 @@ class ipa::server::host::base {
 		recurse => true,		# recursively manage directory
 		purge => true,			# purge all unmanaged files
 		force => true,			# also purge subdirs and links
-		owner => root, group => nobody, mode => 600, backup => false,
+		owner => root, group => nobody, mode => '600', backup => false,
 		require => File["${vardir}/hosts/"],
 	}
 }

--- a/manifests/server/host/pwtag.pp
+++ b/manifests/server/host/pwtag.pp
@@ -31,7 +31,7 @@ define ipa::server::host::pwtag() {
 		content => "# This is a password tag for: ${name}\n",
 		owner => root,
 		group => nobody,
-		mode => 600,	# u=rw,go=
+		mode => '600',	# u=rw,go=
 		backup => false,
 		before => Exec["ipa-host-verify-password-exists-${name}"],
 		require => File["${vardir}/hosts/passwords/"],

--- a/manifests/server/host/sshpubkeys.pp
+++ b/manifests/server/host/sshpubkeys.pp
@@ -31,7 +31,7 @@ define ipa::server::host::sshpubkeys(	# $name matches ipa::server::host $name
 			content => "${rsa}\n",
 			owner => root,
 			group => nobody,
-			mode => 600,	# u=rw,go=
+			mode => '600',	# u=rw,go=
 			backup => false,
 			# this before is essential, and it implies that it will also go
 			# before the "ipa-server-host-mod-${name}" exec, because of the
@@ -47,7 +47,7 @@ define ipa::server::host::sshpubkeys(	# $name matches ipa::server::host $name
 			content => "${dsa}\n",
 			owner => root,
 			group => nobody,
-			mode => 600,	# u=rw,go=
+			mode => '600',	# u=rw,go=
 			backup => false,
 			# this before is essential, and it implies that it will also go
 			# before the "ipa-server-host-mod-${name}" exec, because of the

--- a/manifests/server/replica/base.pp
+++ b/manifests/server/replica/base.pp
@@ -26,7 +26,7 @@ class ipa::server::replica::base {
 		recurse => true,		# recursively manage directory
 		purge => true,			# purge all unmanaged files
 		force => true,			# also purge subdirs and links
-		owner => root, group => nobody, mode => 600, backup => false,
+		owner => root, group => nobody, mode => '600', backup => false,
 		require => File["${vardir}/"],
 	}
 }

--- a/manifests/server/replica/install.pp
+++ b/manifests/server/replica/install.pp
@@ -80,7 +80,7 @@ class ipa::server::replica::install(
 		ensure => present,
 		owner => root,
 		group => nobody,
-		mode => 600,			# u=rw
+		mode => '600',			# u=rw
 		backup => false,		# don't backup to filebucket
 		before => Exec['ipa-install'],
 		require => File["${vardir}/replica/install/"],

--- a/manifests/server/replica/install/base.pp
+++ b/manifests/server/replica/install/base.pp
@@ -27,7 +27,7 @@ class ipa::server::replica::install::base {
 		recurse => true,		# recursively manage directory
 		purge => true,			# purge all unmanaged files
 		force => true,			# also purge subdirs and links
-		owner => root, group => nobody, mode => 600, backup => false,
+		owner => root, group => nobody, mode => '600', backup => false,
 		require => File["${vardir}/replica/"],
 	}
 }

--- a/manifests/server/replica/manage.pp
+++ b/manifests/server/replica/manage.pp
@@ -49,7 +49,7 @@ define ipa::server::replica::manage(	# to
 		content => "${valid_peer}\n${args}\n",
 		owner => root,
 		group => nobody,
-		mode => 600,	# u=rw,go=
+		mode => '600',	# u=rw,go=
 		require => File["${vardir}/replica/manage/peers/"],
 		ensure => present,
 	}

--- a/manifests/server/replica/manage/base.pp
+++ b/manifests/server/replica/manage/base.pp
@@ -27,14 +27,14 @@ class ipa::server::replica::manage::base {
 		recurse => true,		# recursively manage directory
 		purge => true,			# purge all unmanaged files
 		force => true,			# also purge subdirs and links
-		owner => root, group => nobody, mode => 600, backup => false,
+		owner => root, group => nobody, mode => '600', backup => false,
 		require => File["${vardir}/replica/"],
 	}
 
 	# since we don't want to purge them, we need to exclude them...
 	$peer_always_ignore = ["${::fqdn}"]	# never try and purge yourself!
 	$peer_excludes = $ipa::server::peer_excludes
-	$valid_peer_excludes = type($peer_excludes) ? {
+	$valid_peer_excludes = type3x($peer_excludes) ? {
 		'string' => [$peer_excludes],
 		'array' => $peer_excludes,
 		'boolean' => $peer_excludes ? {
@@ -47,7 +47,7 @@ class ipa::server::replica::manage::base {
 		default => false,	# trigger error...
 	}
 
-	if type($valid_peer_excludes) != 'array' {
+	if type3x($valid_peer_excludes) != 'array' {
 		fail('The $peer_excludes must be an array.')
 	}
 
@@ -57,7 +57,7 @@ class ipa::server::replica::manage::base {
 		recurse => true,		# recursively manage directory
 		purge => true,			# purge all unmanaged files
 		force => true,			# also purge subdirs and links
-		owner => root, group => nobody, mode => 600, backup => false,
+		owner => root, group => nobody, mode => '600', backup => false,
 		notify => Exec['ipa-clean-peers'],
 		require => File["${vardir}/replica/manage/"],
 	}
@@ -76,7 +76,7 @@ class ipa::server::replica::manage::base {
 		content => template('ipa/clean.sh.erb'),
 		owner => root,
 		group => nobody,
-		mode => 700,			# u=rwx
+		mode => '700',			# u=rwx
 		backup => false,		# don't backup to filebucket
 		ensure => present,
 		require => File["${vardir}/"],

--- a/manifests/server/replica/master.pp
+++ b/manifests/server/replica/master.pp
@@ -31,7 +31,7 @@ class ipa::server::replica::master(
 		tag => 'ipa-server-replica-master',
 		owner => root,
 		group => nobody,
-		mode => 600,
+		mode => '600',
 		ensure => present,
 	}
 

--- a/manifests/server/replica/master/base.pp
+++ b/manifests/server/replica/master/base.pp
@@ -27,7 +27,7 @@ class ipa::server::replica::master::base {
 		recurse => true,		# recursively manage directory
 		purge => true,			# purge all unmanaged files
 		force => true,			# also purge subdirs and links
-		owner => root, group => nobody, mode => 600, backup => false,
+		owner => root, group => nobody, mode => '600', backup => false,
 		require => File["${vardir}/replica/"],
 	}
 }

--- a/manifests/server/replica/peering.pp
+++ b/manifests/server/replica/peering.pp
@@ -41,7 +41,7 @@ class ipa::server::replica::peering(
 		},
 		owner => root,
 		group => nobody,
-		mode => 600,	# might as well...
+		mode => '600',	# might as well...
 		ensure => present,
 		require => File["${vardir}/replica/peering/"],
 	}
@@ -57,7 +57,7 @@ class ipa::server::replica::peering(
 		tag => 'ipa-server-replica-peering',
 		owner => root,
 		group => nobody,
-		mode => 600,
+		mode => '600',
 		ensure => present,
 	}
 

--- a/manifests/server/replica/peering/base.pp
+++ b/manifests/server/replica/peering/base.pp
@@ -27,7 +27,7 @@ class ipa::server::replica::peering::base {
 		recurse => true,		# recursively manage directory
 		purge => true,			# purge all unmanaged files
 		force => true,			# also purge subdirs and links
-		owner => root, group => nobody, mode => 600, backup => false,
+		owner => root, group => nobody, mode => '600', backup => false,
 		require => File["${vardir}/replica/"],
 	}
 }

--- a/manifests/server/replica/prepare.pp
+++ b/manifests/server/replica/prepare.pp
@@ -46,7 +46,7 @@ define ipa::server::replica::prepare(
 	file { "${valid_file}":
 		owner => root,
 		group => nobody,
-		mode => 600,			# u=rw
+		mode => '600',			# u=rw
 		backup => false,		# don't backup to filebucket
 		ensure => present,
 		require => Exec["ipa-replica-prepare-${name}"],

--- a/manifests/server/replica/prepare/base.pp
+++ b/manifests/server/replica/prepare/base.pp
@@ -27,7 +27,7 @@ class ipa::server::replica::prepare::base {
 		recurse => true,		# recursively manage directory
 		purge => true,			# purge all unmanaged files
 		force => true,			# also purge subdirs and links
-		owner => root, group => nobody, mode => 600, backup => false,
+		owner => root, group => nobody, mode => '600', backup => false,
 		require => File["${vardir}/replica/"],
 	}
 }

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -134,14 +134,16 @@ define ipa::server::service(
 	}
 
 	$pactype_valid = ['MS-PAC', 'PAD']	# or 'NONE'
-	$pactype_array = type($pactype) ? {
+	$pactype_array = type3x($pactype) ? {
 		'array' => $pactype,
 		'string' => ["${pactype}"],
 		default => [],			# will become 'NONE'
 	}
-	$valid_pactype = split(inline_template('<%= ((pactype_array.delete_if {|x| not pactype_valid.include?(x)}.length == 0) ? ["NONE"] : pactype_array.delete_if {|x| not pactype_valid.include?(x)}).join("#") %>'), '#')
+        if ($pactype in $pactype_valid) {
+                $valid_pactype = $pactype_array
+        }
 
-	$args01 = sprintf("--pac-type='%s'", join($valid_pactype, ','))
+        $args01 = ("--pac-type='${valid_pactype}'")
 
 	$arglist = ["${args01}"]	# future expansion available :)
 	$args = join(delete($arglist, ''), ' ')
@@ -152,7 +154,7 @@ define ipa::server::service(
 		content => "${valid_principal}\n${args}\n",
 		owner => root,
 		group => nobody,
-		mode => 600,	# u=rw,go=
+		mode => '600',	# u=rw,go=
 		require => File["${vardir}/services/"],
 		ensure => present,
 	}
@@ -223,7 +225,7 @@ define ipa::server::service(
 		comment => "${comment}",
 		ensure => $ensure,
 		require => Ipa::Client::Host["${name}"],	# should match!
-		tag => "${name}",					# bonus
+#		tag => "${name}",					# bonus
 	}
 }
 

--- a/manifests/server/service/base.pp
+++ b/manifests/server/service/base.pp
@@ -35,7 +35,7 @@ class ipa::server::service::base {
 	$service_always_ignore = suffix($prefix, $append)
 
 	$service_excludes = $ipa::server::service_excludes
-	$valid_service_excludes = type($service_excludes) ? {
+	$valid_service_excludes = type3x($service_excludes) ? {
 		'string' => [$service_excludes],
 		'array' => $service_excludes,
 		'boolean' => $service_excludes ? {
@@ -48,7 +48,7 @@ class ipa::server::service::base {
 		default => false,	# trigger error...
 	}
 
-	if type($valid_service_excludes) != 'array' {
+	if type3x($valid_service_excludes) != 'array' {
 		fail('The $service_excludes must be an array.')
 	}
 
@@ -58,7 +58,7 @@ class ipa::server::service::base {
 		recurse => true,		# recursively manage directory
 		purge => true,			# purge all unmanaged files
 		force => true,			# also purge subdirs and links
-		owner => root, group => nobody, mode => 600, backup => false,
+		owner => root, group => nobody, mode => '600', backup => false,
 		notify => Exec['ipa-clean-services'],
 		require => File["${vardir}/"],
 	}
@@ -77,7 +77,7 @@ class ipa::server::service::base {
 		content => template('ipa/clean.sh.erb'),
 		owner => root,
 		group => nobody,
-		mode => 700,			# u=rwx
+		mode => '700',			# u=rwx
 		backup => false,		# don't backup to filebucket
 		ensure => present,
 		require => File["${vardir}/"],

--- a/manifests/server/user.pp
+++ b/manifests/server/user.pp
@@ -137,7 +137,7 @@ define ipa::server::user(	# $login or principal as a unique id
 		default => "${valid_login}/${valid_instance}@${valid_realm}",
 	}
 
-	$valid_principal = type($principal) ? {
+	$valid_principal = type3x($principal) ? {
 		'string' => "${principal}" ? {
 			'' => "${auto_principal}",
 			default => "${principal}",	# just do what you want
@@ -173,7 +173,7 @@ define ipa::server::user(	# $login or principal as a unique id
 		default => "--last='${last}'",
 	}
 
-	$args03 = type($cn) ? {
+	$args03 = type3x($cn) ? {
 		'string' => "--cn='${cn}'",
 		'boolean' => $cn ? {
 			false => '',
@@ -182,7 +182,7 @@ define ipa::server::user(	# $login or principal as a unique id
 		default => '',
 	}
 
-	$args04 = type($displayname) ? {
+	$args04 = type3x($displayname) ? {
 		'string' => "--displayname='${displayname}'",
 		'boolean' => $displayname ? {
 			false => '',
@@ -191,36 +191,36 @@ define ipa::server::user(	# $login or principal as a unique id
 		default => '',
 	}
 
-	$args05 = type($initials) ? {
+	$args05 = type3x($initials) ? {
 		'string' => "--initials='${displayname}'",
 		'boolean' => $initials ? {
 			false => '',
 			# NOTE: [0,1] is a version robust way to get index 0...
-			default => sprintf("--initials='%s'", inline_template('<%= first[0,1]+last[0,1] %>')),
+                        default => "--initials='${first[0,1]}${last[0,1]}'",
 		},
 		default => '',
 	}
 
 	# email can provide a sensible default
 	$default_email_domain = $ipa::server::default_email_domain
-	$valid_email = type($email) ? {
+	$valid_email = type3x($email) ? {
 		'string' => "${email}" ? {
-			'' => [],	# assume managed but empty (rm values)
-			default => ["${email}"],
+			'' => '',	# assume managed but empty (rm values)
+			default => "${email}",
 		},
 		'array' => $email,
 		'boolean' => $email ? {
 			false => '',	# unmanaged
-			default => ["${valid_login}@${default_email_domain}"],	# sensible default
+			default => "${valid_login}@${default_email_domain}",	# sensible default
 		},
 		default => '',	# unmanaged
 	}
-	$args06 = type($valid_email) ? {
-		'array' => inline_template('<% if valid_email == [] %>--email=<% else %><%= valid_email.map {|x| "--email=\'"+x+"\'" }.join(" ") %><% end %>'),
+	$args06 = type3x($valid_email) ? {
+                'string' => "--email='${valid_email}'",
 		default => '',	# unmanaged
 	}
 
-	$args07 = type($gecos) ? {
+	$args07 = type3x($gecos) ? {
 		'string' => "--gecos='${gecos}'",
 		'boolean' => $gecos ? {
 			false => '',
@@ -230,19 +230,19 @@ define ipa::server::user(	# $login or principal as a unique id
 	}
 
 	# TODO: validate id ranges ?
-	$args08 = type($uid) ? {
+	$args08 = type3x($uid) ? {
 		'string' => "--uid='${uid}'",
 		'integer' => "--uid='${uid}'",
 		default => '',
 	}
 
 	# TODO: validate id ranges ?
-	$args09 = type($gid) ? {
+	$args09 = type3x($gid) ? {
 		'string' => "--gidnumber='${gid}'",
 		'integer' => "--gidnumber='${gid}'",
 		'boolean' => $gid ? {
 			false => '',
-			default => type($uid) ? {	# auto try to match uid
+			default => type3x($uid) ? {	# auto try to match uid
 				'string' => "--gidnumber='${uid}'",	# uid !
 				'integer' => "--gidnumber='${uid}'",	# uid !
 				default => '',	# auto
@@ -252,7 +252,7 @@ define ipa::server::user(	# $login or principal as a unique id
 	}
 
 	$default_shell = $ipa::server::default_shell
-	$args10 = type($shell) ? {
+	$args10 = type3x($shell) ? {
 		'string' => "--shell='${shell}'",
 		'boolean' => $shell ? {
 			false => '',
@@ -263,11 +263,11 @@ define ipa::server::user(	# $login or principal as a unique id
 
 	# TODO: the home stuff seems to not use trailing slashes. can i add it?
 	$default_homes = $ipa::server::default_homes
-	$args11 = type($home) ? {
+	$args11 = type3x($home) ? {
 		'string' => sprintf("--homedir='%s'", regsubst("${home}" , '\/$', '')),
 		'boolean' => $home ? {
 			false => '',
-			default => type($default_homes) ? {
+			default => type3x($default_homes) ? {
 				'string' => sprintf("--homedir='%s/${valid_login}'", regsubst("${default_homes}" , '\/$', '')),
 				# TODO: warning ?
 				default => '',	# can't manage, parent is false
@@ -277,7 +277,7 @@ define ipa::server::user(	# $login or principal as a unique id
 	}
 
 	# users individual ssh public keys
-	$valid_sshpubkeys = type($sshpubkeys) ? {
+	$valid_sshpubkeys = type3x($sshpubkeys) ? {
 		'string' => "${sshpubkeys}" ? {
 			'' => [],	# assume managed but empty (rm values)
 			default => ["${sshpubkeys}"],
@@ -285,13 +285,13 @@ define ipa::server::user(	# $login or principal as a unique id
 		'array' => $sshpubkeys,
 		default => '',	# unmanaged
 	}
-	$args12 = type($valid_sshpubkeys) ? {
+	$args12 = type3x($valid_sshpubkeys) ? {
 		'array' => inline_template('<% if valid_sshpubkeys == [] %>--sshpubkey=<% else %><%= valid_sshpubkeys.map {|x| "--sshpubkey=\'"+x+"\'" }.join(" ") %><% end %>'),
 		default => '',	# unmanaged
 	}
 
 	# mailing address section
-	$args13 = type($street) ? {
+	$args13 = type3x($street) ? {
 		'string' => "--street='${street}'",
 		'boolean' => $street ? {
 			true => '--street=',	# managed
@@ -300,7 +300,7 @@ define ipa::server::user(	# $login or principal as a unique id
 		default => '',			# whatever and unmanaged
 	}
 
-	$args14 = type($city) ? {
+	$args14 = type3x($city) ? {
 		'string' => "--city='${city}'",
 		'boolean' => $city ? {
 			true => '--city=',
@@ -309,7 +309,7 @@ define ipa::server::user(	# $login or principal as a unique id
 		default => '',
 	}
 
-	$args15 = type($state) ? {	# or province
+	$args15 = type3x($state) ? {	# or province
 		'string' => "--state='${state}'",
 		'boolean' => $state ? {
 			true => '--state=',
@@ -318,7 +318,7 @@ define ipa::server::user(	# $login or principal as a unique id
 		default => '',
 	}
 
-	$args16 = type($postalcode) ? {
+	$args16 = type3x($postalcode) ? {
 		'string' => "--postalcode='${postalcode}'",
 		'boolean' => $postalcode ? {
 			true => '--postalcode=',
@@ -328,7 +328,7 @@ define ipa::server::user(	# $login or principal as a unique id
 	}
 
 	# the following four phone number types can be arrays
-	$valid_phone = type($phone) ? {
+	$valid_phone = type3x($phone) ? {
 		'string' => "${phone}" ? {
 			'' => [],	# assume managed but empty (rm values)
 			default => ["${phone}"],
@@ -336,12 +336,12 @@ define ipa::server::user(	# $login or principal as a unique id
 		'array' => $phone,
 		default => '',	# unmanaged
 	}
-	$args17 = type($valid_phone) ? {
+	$args17 = type3x($valid_phone) ? {
 		'array' => inline_template('<% if valid_phone == [] %>--phone=<% else %><%= valid_phone.map {|x| "--phone=\'"+x+"\'" }.join(" ") %><% end %>'),
 		default => '',	# unmanaged
 	}
 
-	$valid_mobile = type($mobile) ? {
+	$valid_mobile = type3x($mobile) ? {
 		'string' => "${mobile}" ? {
 			'' => [],	# assume managed but empty (rm values)
 			default => ["${mobile}"],
@@ -349,12 +349,12 @@ define ipa::server::user(	# $login or principal as a unique id
 		'array' => $mobile,
 		default => '',	# unmanaged
 	}
-	$args18 = type($valid_mobile) ? {
+	$args18 = type3x($valid_mobile) ? {
 		'array' => inline_template('<% if valid_mobile == [] %>--mobile=<% else %><%= valid_mobile.map {|x| "--mobile=\'"+x+"\'" }.join(" ") %><% end %>'),
 		default => '',	# unmanaged
 	}
 
-	$valid_pager = type($pager) ? {
+	$valid_pager = type3x($pager) ? {
 		'string' => "${pager}" ? {
 			'' => [],	# assume managed but empty (rm values)
 			default => ["${pager}"],
@@ -362,12 +362,12 @@ define ipa::server::user(	# $login or principal as a unique id
 		'array' => $pager,
 		default => '',	# unmanaged
 	}
-	$args19 = type($valid_pager) ? {
+	$args19 = type3x($valid_pager) ? {
 		'array' => inline_template('<% if valid_pager == [] %>--pager=<% else %><%= valid_pager.map {|x| "--pager=\'"+x+"\'" }.join(" ") %><% end %>'),
 		default => '',	# unmanaged
 	}
 
-	$valid_fax = type($fax) ? {
+	$valid_fax = type3x($fax) ? {
 		'string' => "${fax}" ? {
 			'' => [],	# assume managed but empty (rm values)
 			default => ["${fax}"],
@@ -375,13 +375,13 @@ define ipa::server::user(	# $login or principal as a unique id
 		'array' => $fax,
 		default => '',	# unmanaged
 	}
-	$args20 = type($valid_fax) ? {
+	$args20 = type3x($valid_fax) ? {
 		'array' => inline_template('<% if valid_fax == [] %>--fax=<% else %><%= valid_fax.map {|x| "--fax=\'"+x+"\'" }.join(" ") %><% end %>'),
 		default => '',	# unmanaged
 	}
 
 	# other information
-	$args21 = type($jobtitle) ? {	# job title
+	$args21 = type3x($jobtitle) ? {	# job title
 		'string' => "--title='${jobtitle}'",
 		'boolean' => $jobtitle ? {
 			true => '--title=',
@@ -390,7 +390,7 @@ define ipa::server::user(	# $login or principal as a unique id
 		default => '',
 	}
 
-	$args22 = type($orgunit) ? {
+	$args22 = type3x($orgunit) ? {
 		'string' => "--orgunit='${orgunit}'",
 		'boolean' => $orgunit ? {
 			true => '--orgunit=',
@@ -401,7 +401,7 @@ define ipa::server::user(	# $login or principal as a unique id
 
 	# manager requires user exists... this lets us match a user principal
 	$valid_manager = regsubst("${manager}", $r, '\1')	# login (james)
-	$args23 = type($manager) ? {	# this has to match an existing user...
+	$args23 = type3x($manager) ? {	# this has to match an existing user...
 		'string' => "--manager='${valid_manager}'",
 		'boolean' => $manager ? {
 			true => '--manager=',
@@ -410,7 +410,7 @@ define ipa::server::user(	# $login or principal as a unique id
 		default => '',
 	}
 
-	$args24 = type($carlicense) ? {
+	$args24 = type3x($carlicense) ? {
 		'string' => "--carlicense='${carlicense}'",
 		'boolean' => $carlicense ? {
 			true => '--carlicense=',
@@ -429,7 +429,7 @@ define ipa::server::user(	# $login or principal as a unique id
 		content => "${valid_login}\n${args}\n",
 		owner => root,
 		group => nobody,
-		mode => 600,	# u=rw,go=
+		mode => '600',	# u=rw,go=
 		require => File["${vardir}/users/"],
 		ensure => present,
 	}
@@ -439,7 +439,7 @@ define ipa::server::user(	# $login or principal as a unique id
 			# no content! this is a tag, content comes in by echo !
 			owner => root,
 			group => nobody,
-			mode => 600,	# u=rw,go=
+			mode => '600',	# u=rw,go=
 			backup => false,
 			require => File["${vardir}/users/passwords/"],
 			ensure => present,
@@ -449,7 +449,7 @@ define ipa::server::user(	# $login or principal as a unique id
 	$exists = "/usr/bin/ipa user-show '${valid_login}' > /dev/null 2>&1"
 	# this requires ensures the $manager user exists when we can check that
 	# this melds together the kinit require which is needed by the user add
-	$requires = type($manager) ? {
+	$requires = type3x($manager) ? {
 		'string' => "${manager}" ? {
 			'' => Exec['ipa-server-kinit'],
 			default => $watch ? {

--- a/manifests/server/user/base.pp
+++ b/manifests/server/user/base.pp
@@ -26,7 +26,7 @@ class ipa::server::user::base {
 	# since we don't want to purge them, we need to exclude them...
 	$user_always_ignore = ['admin']
 	$user_excludes = $ipa::server::user_excludes
-	$valid_user_excludes = type($user_excludes) ? {
+	$valid_user_excludes = type3x($user_excludes) ? {
 		'string' => [$user_excludes],
 		'array' => $user_excludes,
 		'boolean' => $user_excludes ? {
@@ -39,7 +39,7 @@ class ipa::server::user::base {
 		default => false,	# trigger error...
 	}
 
-	if type($valid_user_excludes) != 'array' {
+	if type3x($valid_user_excludes) != 'array' {
 		fail('The $user_excludes must be an array.')
 	}
 
@@ -49,7 +49,7 @@ class ipa::server::user::base {
 		recurse => true,		# recursively manage directory
 		purge => true,			# purge all unmanaged files
 		force => true,			# also purge subdirs and links
-		owner => root, group => nobody, mode => 600, backup => false,
+		owner => root, group => nobody, mode => '600', backup => false,
 		notify => Exec['ipa-clean-users'],
 		require => File["${vardir}/"],
 	}
@@ -68,7 +68,7 @@ class ipa::server::user::base {
 		content => template('ipa/clean.sh.erb'),
 		owner => root,
 		group => nobody,
-		mode => 700,			# u=rwx
+		mode => '700',			# u=rwx
 		backup => false,		# don't backup to filebucket
 		ensure => present,
 		require => File["${vardir}/"],
@@ -90,7 +90,7 @@ class ipa::server::user::base {
 		recurse => true,		# recursively manage directory
 		purge => true,			# purge all unmanaged files
 		force => true,			# also purge subdirs and links
-		owner => root, group => nobody, mode => 600, backup => false,
+		owner => root, group => nobody, mode => '600', backup => false,
 		require => File["${vardir}/users/"],
 	}
 }

--- a/manifests/vardir.pp
+++ b/manifests/vardir.pp
@@ -30,7 +30,7 @@ class ipa::vardir {	# module vardir snippet
 			force => true,		# also purge subdirs and links
 			owner => root,
 			group => nobody,
-			mode => 600,
+			mode => '600',
 			backup => false,	# don't backup to filebucket
 			#before => File["${module_vardir}"],	# redundant
 			#require => Package['puppet'],	# no puppet module seen
@@ -44,7 +44,7 @@ class ipa::vardir {	# module vardir snippet
 		recurse => true,		# recursively manage directory
 		purge => true,			# purge all unmanaged files
 		force => true,			# also purge subdirs and links
-		owner => root, group => nobody, mode => 600, backup => false,
+		owner => root, group => nobody, mode => '600', backup => false,
 		require => File["${tmp}"],	# File['/var/lib/puppet/tmp/']
 	}
 }

--- a/templates/clean.sh.erb
+++ b/templates/clean.sh.erb
@@ -7,20 +7,20 @@
 #
 # NOTE:
 # The following variables were used to build this script:
-#	id_dir:	<%= id_dir %>
-#	ls_cmd:	<%= ls_cmd %>
-#	rm_cmd:	<%= rm_cmd %>
-#	fs_chr: <%= fs_chr %>
-#	suffix: <%= suffix %>
-#	regexp: <%= regexp.join(' ') %>
-#	ignore: <%= ignore.join(' ') %>
+#	id_dir:	<%= @id_dir %>
+#	ls_cmd:	<%= @ls_cmd %>
+#	rm_cmd:	<%= @rm_cmd %>
+#	fs_chr: <%= @fs_chr %>
+#	suffix: <%= @suffix %>
+#	regexp: <%= @regexp.join(' ') %>
+#	ignore: <%= @ignore.join(' ') %>
 #
 
-for i in `<%= ls_cmd %> | /bin/awk -F '<%= fs_chr %>' '{print $1}'`; do
+for i in `<%= @ls_cmd %> | /bin/awk -F '<%= @fs_chr %>' '{print $1}'`; do
 	#echo "$i"
 	found=false
 	# this section is essentially an in_array()
-	for j in <%= scope.lookupvar('::ipa::vardir::module_vardir').gsub(/\/$/, '') %>/<%= id_dir %>/*<%= suffix %>; do
+	for j in <%= scope.lookupvar('::ipa::vardir::module_vardir').gsub(/\/$/, '') %>/<%= @id_dir %>/*<%= @suffix %>; do
 		[ -e "$j" ] || break	# loop in bash properly
 		#echo "found tag: $j"
 		# compare against first line of the file
@@ -31,18 +31,18 @@ for i in `<%= ls_cmd %> | /bin/awk -F '<%= fs_chr %>' '{print $1}'`; do
 		fi
 	done
 
-<% if ignore.is_a?(Array) and ignore != [] -%>
+<% if @ignore.is_a?(Array) and @ignore != [] -%>
 	# check against built in ignores
-<% ignore.each do |x| -%>
+<% @ignore.each do |x| -%>
 	if [ "$i" == '<%= x %>' ]; then
 		found=true
 	fi
 <% end -%>
 
 <% end -%>
-<% if regexp.is_a?(Array) and regexp != [] -%>
+<% if @regexp.is_a?(Array) and @regexp != [] -%>
 	# quoting the match pattern indicate a string match (bash v3.2+)
-<% regexp.each do |m| -%>
+<% @regexp.each do |m| -%>
 	if [[ "$i" =~ <%= m %> ]]; then
 		found=true
 	fi
@@ -52,7 +52,7 @@ for i in `<%= ls_cmd %> | /bin/awk -F '<%= fs_chr %>' '{print $1}'`; do
 	# if not found, not matched, and not ignored, then it should be removed
 	if ! $found; then
 		# echo "Removing: $i"
-		<%= rm_cmd %>"$i"
+		<%= @rm_cmd %>"$i"
 	fi
 done
 


### PR DESCRIPTION
These main things are changed:
 - Function type is no longer supported. Modified it to type3x.
 - File mode needed to be a string. Not an int
 - Variables in templates needed to have an @ in front of them
 - $FW variable needed to be lower case
 - inline_template removed on several locations

I have tested the installation of ipa-server, the creation of a user and adding of a service.
Not tested:
 - Client installation
 - Replica
 - Adding a host

There is still an issue when running the puppet agent a second time. The puppet code "thinks" it needs to change the user on every run but that fails with "/returns: ipa: ERROR: no modifications to be performed". Probably an error in diff.py.
When running diff.py manually, i get the following error:
```
./diff.py user ntesla --first='Nikola' --last='Tesla' --cn='Nikola Tesla' --displayname='Nikola Tesla' --initials='NT' --email='ntesla@core.cmc.lan' --gecos='Nikola Tesla' --shell='/bin/sh' --homedir='/home/ntesla'
ipa: INFO: trying https://puppetdev-fabian02.core.cmc.lan/ipa/session/xml
ipa: INFO: Forwarding 'user_show' to json server 'https://puppetdev-fabian02.core.cmc.lan/ipa/session/xml'
Traceback (most recent call last):
  File "./diff.py", line 531, in <module>
    output = ipalib.api.Command.user_show(unicode(args.primarykey), all=True)
  File "/usr/lib/python2.7/site-packages/ipalib/frontend.py", line 442, in __call__
    ret = self.run(*args, **options)
  File "/usr/lib/python2.7/site-packages/ipalib/frontend.py", line 760, in run
    return self.forward(*args, **options)
  File "/usr/lib/python2.7/site-packages/ipalib/plugins/user.py", line 825, in forward
    return super(user_show, self).forward(*keys, **options)
  File "/usr/lib/python2.7/site-packages/ipalib/frontend.py", line 781, in forward
    return self.Backend.rpcclient.forward(self.name, *args, **kw)
  File "/usr/lib/python2.7/site-packages/ipalib/rpc.py", line 885, in forward
    command = getattr(self.conn, name)
  File "/usr/lib/python2.7/site-packages/ipalib/backend.py", line 97, in __get_conn
    self.id, threading.currentThread().getName())
```

But the basic installation of ipa-server works fine.